### PR TITLE
feat(ejs): 에디터 viewer 설정

### DIFF
--- a/nextjs-client/package-lock.json
+++ b/nextjs-client/package-lock.json
@@ -25,6 +25,7 @@
         "react": "18.2.0",
         "react-dom": "18.2.0",
         "react-simple-code-editor": "^0.13.1",
+        "striptags": "^3.2.0",
         "tailwindcss": "3.3.2",
         "typescript": "5.1.6"
       },
@@ -4148,6 +4149,11 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/striptags": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/striptags/-/striptags-3.2.0.tgz",
+      "integrity": "sha512-g45ZOGzHDMe2bdYMdIvdAfCQkCTDMGBazSw1ypMowwGIee7ZQ5dU0rBJ8Jqgl+jAKIv4dbeE1jscZq9wid1Tkw=="
+    },
     "node_modules/styled-jsx": {
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/styled-jsx/-/styled-jsx-5.1.1.tgz",
@@ -7288,6 +7294,11 @@
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
       "integrity": "sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig=="
+    },
+    "striptags": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/striptags/-/striptags-3.2.0.tgz",
+      "integrity": "sha512-g45ZOGzHDMe2bdYMdIvdAfCQkCTDMGBazSw1ypMowwGIee7ZQ5dU0rBJ8Jqgl+jAKIv4dbeE1jscZq9wid1Tkw=="
     },
     "styled-jsx": {
       "version": "5.1.1",

--- a/nextjs-client/package-lock.json
+++ b/nextjs-client/package-lock.json
@@ -16,6 +16,7 @@
         "@types/react-dom": "18.2.6",
         "autoprefixer": "10.4.14",
         "classnames": "^2.3.2",
+        "editorjs-html": "^3.4.3",
         "eslint-config-next": "13.4.9",
         "eslint-plugin-unused-imports": "2.0.0",
         "next": "13.4.9",
@@ -1373,6 +1374,11 @@
       "engines": {
         "node": ">=6.0.0"
       }
+    },
+    "node_modules/editorjs-html": {
+      "version": "3.4.3",
+      "resolved": "https://registry.npmjs.org/editorjs-html/-/editorjs-html-3.4.3.tgz",
+      "integrity": "sha512-HMqQ3BCE98uhSpJsbfH0c3CoMctUMCHlap2Eq/7/VjaHas+g3IJqyf+ERtMByoQCzvcW22ISYaZEeE7rGkd8Xg=="
     },
     "node_modules/electron-to-chromium": {
       "version": "1.4.455",
@@ -5467,6 +5473,11 @@
       "requires": {
         "esutils": "^2.0.2"
       }
+    },
+    "editorjs-html": {
+      "version": "3.4.3",
+      "resolved": "https://registry.npmjs.org/editorjs-html/-/editorjs-html-3.4.3.tgz",
+      "integrity": "sha512-HMqQ3BCE98uhSpJsbfH0c3CoMctUMCHlap2Eq/7/VjaHas+g3IJqyf+ERtMByoQCzvcW22ISYaZEeE7rGkd8Xg=="
     },
     "electron-to-chromium": {
       "version": "1.4.455",

--- a/nextjs-client/package.json
+++ b/nextjs-client/package.json
@@ -17,6 +17,7 @@
     "@types/react-dom": "18.2.6",
     "autoprefixer": "10.4.14",
     "classnames": "^2.3.2",
+    "editorjs-html": "^3.4.3",
     "eslint-config-next": "13.4.9",
     "eslint-plugin-unused-imports": "2.0.0",
     "next": "13.4.9",

--- a/nextjs-client/package.json
+++ b/nextjs-client/package.json
@@ -26,6 +26,7 @@
     "react": "18.2.0",
     "react-dom": "18.2.0",
     "react-simple-code-editor": "^0.13.1",
+    "striptags": "^3.2.0",
     "tailwindcss": "3.3.2",
     "typescript": "5.1.6"
   },

--- a/nextjs-client/src/app/test/page.tsx
+++ b/nextjs-client/src/app/test/page.tsx
@@ -3,6 +3,7 @@ import type { OutputData } from '@editorjs/editorjs'
 import { useEffect, useState } from 'react'
 
 import { EditorBlock } from '@/components'
+import Viewer from '@/components/Editor/viewer'
 
 export default function Page() {
   const [data, setData] = useState<OutputData>()
@@ -12,8 +13,19 @@ export default function Page() {
   }, [data])
 
   return (
-    <main className='bg-white text-black'>
-      <EditorBlock data={data} onChangeEditor={setData} holder='editorjs-container' />
-    </main>
+    <div className='m-10 flex gap-x-8'>
+      <div className='col-span-1 w-full'>
+        <h1>Editor</h1>
+        <div className='rounded-md border border-black'>
+          <EditorBlock data={data} onChangeEditor={setData} holder='editorjs-container' />
+        </div>
+      </div>
+      <div className='col-span-1 w-full'>
+        <h1>Preview</h1>
+        <div className='rounded-md border border-black'>
+          <div className='min-h-[338px]'>{data && <Viewer data={data} />}</div>
+        </div>
+      </div>
+    </div>
   )
 }

--- a/nextjs-client/src/app/test/page.tsx
+++ b/nextjs-client/src/app/test/page.tsx
@@ -14,16 +14,16 @@ export default function Page() {
 
   return (
     <div className='m-10 flex gap-x-8'>
-      <div className='col-span-1 w-full'>
+      <div className='w-full'>
         <h1>Editor</h1>
         <div className='rounded-md border border-black'>
           <EditorBlock data={data} onChangeEditor={setData} holder='editorjs-container' />
         </div>
       </div>
-      <div className='col-span-1 w-full'>
+      <div className='w-full'>
         <h1>Preview</h1>
         <div className='rounded-md border border-black'>
-          <div className='min-h-[338px]'>{data && <Viewer data={data} />}</div>
+          <div className='min-h-[338px] pb-[300px]'>{data && <Viewer data={data} />}</div>
         </div>
       </div>
     </div>

--- a/nextjs-client/src/components/Editor/PrismWrapper.tsx
+++ b/nextjs-client/src/components/Editor/PrismWrapper.tsx
@@ -7,9 +7,10 @@ import 'prismjs/themes/prism.css'
 
 type Props = {
   code: string
+  readOnly?: boolean
 } & React.HTMLAttributes<HTMLTextAreaElement>
 
-const PrismWrapper = ({ code, className }: Props) => {
+const PrismWrapper = ({ code, className, readOnly = false }: Props) => {
   const [value, setValue] = React.useState(code)
 
   useEffect(() => {
@@ -23,6 +24,7 @@ const PrismWrapper = ({ code, className }: Props) => {
       onValueChange={setValue}
       highlight={(code) => highlight(code, languages.js, 'js')}
       padding={10}
+      readOnly={readOnly}
     />
   )
 }

--- a/nextjs-client/src/components/Editor/viewer.tsx
+++ b/nextjs-client/src/components/Editor/viewer.tsx
@@ -1,0 +1,25 @@
+import { OutputData } from '@editorjs/editorjs'
+import editorJsHtml from 'editorjs-html'
+
+type Props = {
+  data?: OutputData
+}
+type ParsedContent = string | JSX.Element
+
+const Viewer = ({ data }: Props) => {
+  const html = data ? (editorJsHtml().parse(data) as ParsedContent[]) : []
+
+  return (
+    //✔️ It's important to add key={data.time} here to re-render based on the latest data.
+    <div className='prose max-w-full' key={data?.time}>
+      {html.map((item, index) => {
+        if (typeof item === 'string') {
+          return <div dangerouslySetInnerHTML={{ __html: item }} key={index}></div>
+        }
+        return item
+      })}
+    </div>
+  )
+}
+
+export default Viewer

--- a/nextjs-client/src/components/Editor/viewer.tsx
+++ b/nextjs-client/src/components/Editor/viewer.tsx
@@ -1,22 +1,38 @@
 import { OutputData } from '@editorjs/editorjs'
 import editorJsHtml from 'editorjs-html'
+import striptags from 'striptags'
+
+import PrismWrapper from './PrismWrapper'
 
 type Props = {
   data?: OutputData
 }
-type ParsedContent = string | JSX.Element
+type ParsedContent = string
+
+function isCodeBlock(data: ParsedContent) {
+  return data.startsWith('<pre><code>') && data.endsWith('</code></pre>')
+}
+
+function isImageBlock(data: ParsedContent) {
+  return data.startsWith('<img ') && data.endsWith('/>')
+}
 
 const Viewer = ({ data }: Props) => {
   const html = data ? (editorJsHtml().parse(data) as ParsedContent[]) : []
 
   return (
     //✔️ It's important to add key={data.time} here to re-render based on the latest data.
-    <div className='prose max-w-full' key={data?.time}>
+    <div className='prose' key={data?.time}>
       {html.map((item, index) => {
-        if (typeof item === 'string') {
-          return <div dangerouslySetInnerHTML={{ __html: item }} key={index}></div>
-        }
-        return item
+        if (isCodeBlock(item))
+          return (
+            <div className='cdx-block ce-block__content ce-code'>
+              <PrismWrapper readOnly code={striptags(item)} className='ce-code__textarea cdx-input' />
+            </div>
+          )
+        else if (isImageBlock(item))
+          return <div dangerouslySetInnerHTML={{ __html: item }} className='cdx-block ce-block__content image-tool__image' key={index} />
+        else return <div dangerouslySetInnerHTML={{ __html: item }} className='cdx-block ce-block__content ce-paragraph' key={index} />
       })}
     </div>
   )


### PR DESCRIPTION
## 작업 이유
에디터 뷰어를 테스트합니두
## 작업 사항
에디터에 `일반 블럭`, `코드 블럭`, `이미지` 에 대응되는 viewer 를 만드러봅니다.

https://github.com/80000Coding/80000Coding-Web-Client/assets/76505351/d9fe1253-3c89-4e76-b206-4ae8e0a07089


## 이슈 연결

