### PR TITLE
✨ image S3 upload 기능 구현

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9484,6 +9484,76 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/aws-sdk": {
+      "version": "2.1431.0",
+      "resolved": "https://registry.npmjs.org/aws-sdk/-/aws-sdk-2.1431.0.tgz",
+      "integrity": "sha512-p6NGyI6+BgojiGn6uW2If6v7uxRPO5C+aGy/M+9/Rhdk8a5n7l0123v9ZUnEJgAy0tsNkazL2ifzV33nc0aGNA==",
+      "dependencies": {
+        "buffer": "4.9.2",
+        "events": "1.1.1",
+        "ieee754": "1.1.13",
+        "jmespath": "0.16.0",
+        "querystring": "0.2.0",
+        "sax": "1.2.1",
+        "url": "0.10.3",
+        "util": "^0.12.4",
+        "uuid": "8.0.0",
+        "xml2js": "0.5.0"
+      },
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/aws-sdk/node_modules/buffer": {
+      "version": "4.9.2",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-4.9.2.tgz",
+      "integrity": "sha512-xq+q3SRMOxGivLhBNaUdC64hDTQwejJ+H0T/NB1XMtTVEwNTrfFF3gAxiyW0Bu/xWEGhjVKgUcMhCrUy2+uCWg==",
+      "dependencies": {
+        "base64-js": "^1.0.2",
+        "ieee754": "^1.1.4",
+        "isarray": "^1.0.0"
+      }
+    },
+    "node_modules/aws-sdk/node_modules/events": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/events/-/events-1.1.1.tgz",
+      "integrity": "sha512-kEcvvCBByWXGnZy6JUlgAp2gBIUjfCAV6P6TgT1/aaQKcmuAEC4OZTV1I4EWQLz2gxZw76atuVyvHhTxvi0Flw==",
+      "engines": {
+        "node": ">=0.4.x"
+      }
+    },
+    "node_modules/aws-sdk/node_modules/ieee754": {
+      "version": "1.1.13",
+      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.1.13.tgz",
+      "integrity": "sha512-4vf7I2LYV/HaWerSo3XmlMkp5eZ83i+/CDluXi/IGTs/O1sejBNhTtnxzmRZfvOUqj7lZjqHkeTvpgSFDlWZTg=="
+    },
+    "node_modules/aws-sdk/node_modules/isarray": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+      "integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ=="
+    },
+    "node_modules/aws-sdk/node_modules/punycode": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.3.2.tgz",
+      "integrity": "sha512-RofWgt/7fL5wP1Y7fxE7/EmTLzQVnB0ycyibJ0OOHIlJqTNzglYFxVwETOcIoJqJmpDXJ9xImDv+Fq34F/d4Dw=="
+    },
+    "node_modules/aws-sdk/node_modules/url": {
+      "version": "0.10.3",
+      "resolved": "https://registry.npmjs.org/url/-/url-0.10.3.tgz",
+      "integrity": "sha512-hzSUW2q06EqL1gKM/a+obYHLIO6ct2hwPuviqTTOcfFVc61UbfJ2Q32+uGL/HCPxKqrdGB5QUwIe7UqlDgwsOQ==",
+      "dependencies": {
+        "punycode": "1.3.2",
+        "querystring": "0.2.0"
+      }
+    },
+    "node_modules/aws-sdk/node_modules/uuid": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.0.0.tgz",
+      "integrity": "sha512-jOXGuXZAWdsTH7eZLtyXMqUb9EcWMGZNbL9YcGBJl4MH4nrxHmZJhEHvyLFrkxo+28uLb/NYRcStH48fnD0Vzw==",
+      "bin": {
+        "uuid": "dist/bin/uuid"
+      }
+    },
     "node_modules/axe-core": {
       "version": "4.7.2",
       "resolved": "https://registry.npmjs.org/axe-core/-/axe-core-4.7.2.tgz",
@@ -9813,7 +9883,6 @@
       "version": "1.5.1",
       "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
       "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
-      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -14820,7 +14889,6 @@
       "version": "1.0.10",
       "resolved": "https://registry.npmjs.org/is-generator-function/-/is-generator-function-1.0.10.tgz",
       "integrity": "sha512-jsEjy9l3yiXEQ+PsXdmBwEPcOxaXWLspKdplFUVI9vq1iZgIekeC0L167qeu86czQaxed3q/Uzuw0swL0irL8A==",
-      "dev": true,
       "dependencies": {
         "has-tostringtag": "^1.0.0"
       },
@@ -15630,6 +15698,14 @@
       "integrity": "sha512-oVhqoRDaBXf7sjkll95LHVS6Myyyb1zaunVwk4Z0+WPSW4gjS0pl01zYKHScTuyEhQsFxV5L4DR5r+YqSyqyyg==",
       "bin": {
         "jiti": "bin/jiti.js"
+      }
+    },
+    "node_modules/jmespath": {
+      "version": "0.16.0",
+      "resolved": "https://registry.npmjs.org/jmespath/-/jmespath-0.16.0.tgz",
+      "integrity": "sha512-9FzQjJ7MATs1tSpnco1K6ayiYE3figslrXA72G2HQ/n76RzvYlofyi5QM+iX4YRs/pu3yzxlVQSST23+dMDknw==",
+      "engines": {
+        "node": ">= 0.6.0"
       }
     },
     "node_modules/js-tokens": {
@@ -18458,6 +18534,15 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/querystring": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/querystring/-/querystring-0.2.0.tgz",
+      "integrity": "sha512-X/xY82scca2tau62i9mDyU9K+I+djTMUsvwf7xnUX5GLvVzgJybOJf4Y6o9Zx3oJK/LSXg5tTZBjwzqVPaPO2g==",
+      "deprecated": "The querystring API is considered Legacy. new code should use the URLSearchParams API instead.",
+      "engines": {
+        "node": ">=0.4.x"
+      }
+    },
     "node_modules/querystring-es3": {
       "version": "0.2.1",
       "resolved": "https://registry.npmjs.org/querystring-es3/-/querystring-es3-0.2.1.tgz",
@@ -19678,6 +19763,11 @@
           "optional": true
         }
       }
+    },
+    "node_modules/sax": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/sax/-/sax-1.2.1.tgz",
+      "integrity": "sha512-8I2a3LovHTOpm7NV5yOyO8IHqgVsfK4+UuySrXU8YXkSRX7k6hCV9b3HrkKCr3nMpgj+0bmocaJJWpvp1oc7ZA=="
     },
     "node_modules/scheduler": {
       "version": "0.23.0",
@@ -21789,7 +21879,6 @@
       "version": "0.12.5",
       "resolved": "https://registry.npmjs.org/util/-/util-0.12.5.tgz",
       "integrity": "sha512-kZf/K6hEIrWHI6XqOFUiiMa+79wE/D8Q+NCNAWclkyg3b4d2k7s0QGepNjiABc+aR3N1PAyHL7p6UcLY6LmrnA==",
-      "dev": true,
       "dependencies": {
         "inherits": "^2.0.3",
         "is-arguments": "^1.0.4",
@@ -22321,6 +22410,26 @@
         }
       }
     },
+    "node_modules/xml2js": {
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.5.0.tgz",
+      "integrity": "sha512-drPFnkQJik/O+uPKpqSgr22mpuFHqKdbS835iAQrUC73L2F5WkboIRd63ai/2Yg6I1jzifPFKH2NTK+cfglkIA==",
+      "dependencies": {
+        "sax": ">=0.6.0",
+        "xmlbuilder": "~11.0.0"
+      },
+      "engines": {
+        "node": ">=4.0.0"
+      }
+    },
+    "node_modules/xmlbuilder": {
+      "version": "11.0.1",
+      "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-11.0.1.tgz",
+      "integrity": "sha512-fDlsI/kFEx7gLvbecc0/ohLG50fugQp8ryHzMTuW9vSa1GJ0XYWKnhsUx7oie3G98+r56aTQIUB4kht42R3JvA==",
+      "engines": {
+        "node": ">=4.0"
+      }
+    },
     "node_modules/xtend": {
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.2.tgz",
@@ -22484,6 +22593,7 @@
         "@types/react": "18.2.14",
         "@types/react-dom": "18.2.6",
         "autoprefixer": "10.4.14",
+        "aws-sdk": "^2.1431.0",
         "classnames": "^2.3.2",
         "eslint-config-next": "13.4.9",
         "eslint-plugin-unused-imports": "2.0.0",

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -17,6 +17,7 @@
     "@types/react": "18.2.14",
     "@types/react-dom": "18.2.6",
     "autoprefixer": "10.4.14",
+    "aws-sdk": "^2.1431.0",
     "classnames": "^2.3.2",
     "eslint-config-next": "13.4.9",
     "eslint-plugin-unused-imports": "2.0.0",

--- a/packages/web/src/components/RemirrorEditor/RemirrorEditor.const.ts
+++ b/packages/web/src/components/RemirrorEditor/RemirrorEditor.const.ts
@@ -39,5 +39,8 @@ playtime is just beginning
 3. List
 
 ![A random image](https://picsum.photos/seed/picsum/200/300)
+![A uploaded image](https://80000coding.s3.ap-northeast-2.amazonaws.com/image.png)
+
+
 
 `

--- a/packages/web/src/components/RemirrorEditor/upload.ts
+++ b/packages/web/src/components/RemirrorEditor/upload.ts
@@ -1,0 +1,74 @@
+import AWS from 'aws-sdk'
+
+type ImagePaths = string[]
+type ParsedDataUrl = {
+  mimeType: string
+  base64: string
+  fileExtension: string
+}
+
+function parseDataUrl(dataUrl: string): ParsedDataUrl {
+  const matches = dataUrl.match(/^data:image\/(.*?);base64,(.*)$/)
+  if (matches && matches.length >= 3) {
+    return {
+      mimeType: 'image/' + matches[1],
+      base64: matches[2],
+      fileExtension: matches[1],
+    }
+  }
+  throw new Error('Cannot parse data URL')
+}
+
+function base64ToBlob(base64: string, mimeType: string) {
+  const byteCharacters = atob(base64)
+  const byteArray = new Uint8Array(byteCharacters.length)
+
+  for (let i = 0; i < byteCharacters.length; i++) {
+    byteArray[i] = byteCharacters.charCodeAt(i)
+  }
+
+  return new Blob([byteArray], { type: mimeType })
+}
+
+function DataUrlToFile(dataUrl: string, filename: string): File {
+  const parsedDataUrl = parseDataUrl(dataUrl)
+  const blob = base64ToBlob(parsedDataUrl.base64, parsedDataUrl.mimeType)
+  return new File([blob], filename, { type: parsedDataUrl.mimeType })
+}
+
+export async function upload(imagePaths: ImagePaths) {
+  const region = 'ap-northeast-2'
+  const bucket = '80000coding'
+
+  AWS.config.update({
+    region: region,
+    accessKeyId: process.env.NEXT_PUBLIC_AWS_ACCESS_KEY_ID,
+    secretAccessKey: process.env.NEXT_PUBLIC_AWS_SECRET_ACCESS_KEY,
+  })
+
+  for (const path of imagePaths) {
+    try {
+      // 파일 이름 어떻게 할지 고민해보기 (현재는 timestamp + file.name) -> timestamp는 우선 중복떄문에 넣어둠
+      const file = DataUrlToFile(path, 'image.png')
+      const timestamp = new Date().getTime()
+
+      const manager = new AWS.S3.ManagedUpload({
+        params: {
+          Bucket: bucket, // 버킷 이름
+          Key: timestamp + file.name, // 버킷에 저장될 파일 이름
+          Body: file, // 파일 객체
+        },
+      })
+      manager.promise().then(
+        function (data) {
+          console.log('upload success', data)
+        },
+        function (err) {
+          console.log('upload error', err)
+        },
+      )
+    } catch (error) {
+      console.error('Error:', error)
+    }
+  }
+}


### PR DESCRIPTION
## 작업 이유
image파일 S3에 업로드하는 기능 추가

> 해당 브랜치에서 작업하기 위해선 AWS key가 필요합니다. 
> 개발팀 Notion에 관련 내용 첨부해두겠습니다.


## 작업 사항
* S3 버킷 생서
* Cloudfront - S3 연결 

### image upload 기능 작동 순서
1. markdown 문서 작성
2. `save`버튼 클릭
3. markdown에서 모든 이미지 경로 추출(정규표현식)
4. 이미지 경로 중 `data:image/...` 형태의 이미지만 upload진행(http... 형태의 이미지는 저장하지 않아도 될 것 같음)
5. upload 진행된 이미지는 기존 url을 업로드된 image url 로 변경
6. markdown 저장

image를 등록할 때마다 저장하는 방식에서 `save` 버튼을 누를 때, 모든 이미지 경로를 추출해 저장하는 방식으로 변경

## 이슈 연결


