### PR TITLE
✨ svg icon에 default class로 icon-md 추가

### DIFF
--- a/packages/web-icons/rollup.config.mjs
+++ b/packages/web-icons/rollup.config.mjs
@@ -150,8 +150,9 @@ function svgBuild(options = {}) {
       }
 
       const rawSvg = fs.readFileSync(id, 'utf8')
-      if (!id.startsWith(iconBasePath + '/dynamic')) {
-        svgoConfig.plugins.push({
+      const curSvgoConfig = { plugins: [...svgoConfig.plugins] }
+      if (id.startsWith(iconBasePath + '/dynamic')) {
+        curSvgoConfig.plugins.push({
           name: 'convertColors',
           params: {
             currentColor: true,
@@ -159,7 +160,7 @@ function svgBuild(options = {}) {
         })
       }
       const { data: optimizedSvgCode } = optimize(rawSvg, {
-        ...svgoConfig,
+        ...curSvgoConfig,
         path: id,
       })
 

--- a/packages/web-icons/rollup.config.mjs
+++ b/packages/web-icons/rollup.config.mjs
@@ -122,24 +122,6 @@ function svgBuild(options = {}) {
       },
     ],
   }
-  const svgoConfigForDynamic = {
-    plugins: [
-      {
-        name: 'preset-default',
-        params: {
-          overrides: {
-            removeViewBox: false,
-          },
-        },
-      },
-      {
-        name: 'convertColors',
-        params: {
-          currentColor: true,
-        },
-      },
-    ],
-  }
 
   /**
    * @type {import('@svgr/babel-plugin-transform-svg-component').Template}
@@ -168,9 +150,16 @@ function svgBuild(options = {}) {
       }
 
       const rawSvg = fs.readFileSync(id, 'utf8')
-      const curSvgoConfig = id.startsWith(iconBasePath + '/dynamic') ? svgoConfigForDynamic : svgoConfig
+      if (!id.startsWith(iconBasePath + '/dynamic')) {
+        svgoConfig.plugins.push({
+          name: 'convertColors',
+          params: {
+            currentColor: true,
+          },
+        })
+      }
       const { data: optimizedSvgCode } = optimize(rawSvg, {
-        ...curSvgoConfig,
+        ...svgoConfig,
         path: id,
       })
 

--- a/packages/web-icons/rollup.config.mjs
+++ b/packages/web-icons/rollup.config.mjs
@@ -114,6 +114,12 @@ function svgBuild(options = {}) {
           },
         },
       },
+      {
+        name: 'addClassesToSVGElement',
+        params: {
+          className: 'icon-md',
+        },
+      },
     ],
   }
   const svgoConfigForDynamic = {


### PR DESCRIPTION
## 작업 이유
svg icon에 default class를 추가했습니다.

기존에는 icon-md 사이즈에 대해서도 className을 추가했었습니다. **이제는 `icon-md` 클래스는 생략할 수 있습니다.**

```jsx
// 작업 전
<DynamicAddIcon  className='icon-md' />

// 작업 후
<DynamicAddIcon />
```

## 작업 내용
`addAttributesToSVGElement` 플러그인을 활용해서 default로 width, height 값을 지정하려고 했는데, `icon-md` 클래스를 지정하는 방식이 조금 더 장점이 있어보여서 `addClassesToSVGElement` 플러그인을 사용하기로 결정하였습니다. 

아래는 icon이 html로 랜더링 되는 결과를 나타냅니다.

```html
// 기존에 생각했던 결과
<svg width='28' height='28' .... />

// 변경된 결과
<svg class='icon-md' .... />
```

만약 client에서 `icon-md`클래스에 대한 정의가 없어진다면, 스타일 지정이 무효가 되는 문제가 발생할 수 있지만, `icon-md`클래스 자체의 스펙 변경, 추가될 스타일의 우선순위 설정에서의 편리함이 큰 장점이라고 생각했습니다.

## 이슈 연결
close #80 

