### PR TITLE
♻️ package-lock에 name 추가

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -24,6 +24,7 @@
       }
     },
     "apps/web": {
+      "name": "@80000coding/web",
       "version": "1.0.1",
       "dependencies": {
         "@80000coding/web-icons": "^1.0.1",


### PR DESCRIPTION
## 작업 이유
패키지 재구성으로 package-lock.json에 name부분 빠져있던 문제 수정