### PR TITLE
♻️ deprecated 된 의존성 업데이트

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -28085,21 +28085,6 @@
         "fsevents": "~2.3.2"
       }
     },
-    "node_modules/rollup-plugin-babel": {
-      "version": "4.4.0",
-      "resolved": "https://registry.npmjs.org/rollup-plugin-babel/-/rollup-plugin-babel-4.4.0.tgz",
-      "integrity": "sha512-Lek/TYp1+7g7I+uMfJnnSJ7YWoD58ajo6Oarhlex7lvUce+RCKRuGRSgztDO3/MF/PuGKmUL5iTHKf208UNszw==",
-      "deprecated": "This package has been deprecated and is no longer maintained. Please use @rollup/plugin-babel.",
-      "dev": true,
-      "dependencies": {
-        "@babel/helper-module-imports": "^7.0.0",
-        "rollup-pluginutils": "^2.8.1"
-      },
-      "peerDependencies": {
-        "@babel/core": "7 || ^7.0.0-rc.2",
-        "rollup": ">=0.60.0 <3"
-      }
-    },
     "node_modules/rollup-plugin-peer-deps-external": {
       "version": "2.2.4",
       "resolved": "https://registry.npmjs.org/rollup-plugin-peer-deps-external/-/rollup-plugin-peer-deps-external-2.2.4.tgz",
@@ -28218,66 +28203,6 @@
       }
     },
     "node_modules/rollup-plugin-postcss/node_modules/supports-color": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
-      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
-      "dev": true,
-      "dependencies": {
-        "has-flag": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/rollup-plugin-terser": {
-      "version": "7.0.2",
-      "resolved": "https://registry.npmjs.org/rollup-plugin-terser/-/rollup-plugin-terser-7.0.2.tgz",
-      "integrity": "sha512-w3iIaU4OxcF52UUXiZNsNeuXIMDvFrr+ZXK6bFZ0Q60qyVfq4uLptoS4bbq3paG3x216eQllFZX7zt6TIImguQ==",
-      "deprecated": "This package has been deprecated and is no longer maintained. Please use @rollup/plugin-terser",
-      "dev": true,
-      "dependencies": {
-        "@babel/code-frame": "^7.10.4",
-        "jest-worker": "^26.2.1",
-        "serialize-javascript": "^4.0.0",
-        "terser": "^5.0.0"
-      },
-      "peerDependencies": {
-        "rollup": "^2.0.0"
-      }
-    },
-    "node_modules/rollup-plugin-terser/node_modules/has-flag": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
-      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
-      "dev": true,
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/rollup-plugin-terser/node_modules/jest-worker": {
-      "version": "26.6.2",
-      "resolved": "https://registry.npmjs.org/jest-worker/-/jest-worker-26.6.2.tgz",
-      "integrity": "sha512-KWYVV1c4i+jbMpaBC+U++4Va0cp8OisU185o73T1vo99hqi7w8tSJfUXYswwqqrjzwxa6KpRK54WhPvwf5w6PQ==",
-      "dev": true,
-      "dependencies": {
-        "@types/node": "*",
-        "merge-stream": "^2.0.0",
-        "supports-color": "^7.0.0"
-      },
-      "engines": {
-        "node": ">= 10.13.0"
-      }
-    },
-    "node_modules/rollup-plugin-terser/node_modules/serialize-javascript": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-4.0.0.tgz",
-      "integrity": "sha512-GaNA54380uFefWghODBWEGisLZFj00nS5ACs6yHa9nLqlLpVLO8ChDGeKRjZnV4Nh4n0Qi7nhYZD/9fCPzEqkw==",
-      "dev": true,
-      "dependencies": {
-        "randombytes": "^2.1.0"
-      }
-    },
-    "node_modules/rollup-plugin-terser/node_modules/supports-color": {
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
       "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
@@ -32183,19 +32108,18 @@
         "classnames": "^2.3.2"
       },
       "devDependencies": {
+        "@rollup/plugin-babel": "^6.0.3",
+        "@rollup/plugin-terser": "^0.4.3",
         "@types/react": "^18.0.9",
         "@types/react-dom": "^18.0.4",
         "autoprefixer": "^10.4.15",
         "babel-loader": "^8.2.5",
-        "eslint": "^8.15.0",
         "eslint-config-custom": "*",
         "postcss": "^8.4.28",
         "react": "^18.1.0",
         "rollup": "^2.75.7",
-        "rollup-plugin-babel": "^4.4.0",
         "rollup-plugin-peer-deps-external": "^2.2.4",
         "rollup-plugin-postcss": "^4.0.2",
-        "rollup-plugin-terser": "^7.0.2",
         "tailwindcss": "^3.3.2",
         "tsconfig": "*",
         "tsup": "^5.10.1"

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -17,22 +17,21 @@
     "clean": "rm -rf .turbo && rm -rf node_modules && rm -rf dist"
   },
   "devDependencies": {
+    "@rollup/plugin-babel": "^6.0.3",
+    "@rollup/plugin-terser": "^0.4.3",
     "@types/react": "^18.0.9",
     "@types/react-dom": "^18.0.4",
     "autoprefixer": "^10.4.15",
-    "eslint": "^8.15.0",
+    "babel-loader": "^8.2.5",
     "eslint-config-custom": "*",
     "postcss": "^8.4.28",
     "react": "^18.1.0",
-    "tailwindcss": "^3.3.2",
-    "tsconfig": "*",
-    "tsup": "^5.10.1",
     "rollup": "^2.75.7",
-    "rollup-plugin-babel": "^4.4.0",
     "rollup-plugin-peer-deps-external": "^2.2.4",
     "rollup-plugin-postcss": "^4.0.2",
-    "rollup-plugin-terser": "^7.0.2",
-    "babel-loader": "^8.2.5"
+    "tailwindcss": "^3.3.2",
+    "tsconfig": "*",
+    "tsup": "^5.10.1"
   },
   "peerDependencies": {
     "react": "^18.1.0"


### PR DESCRIPTION
## 작업 이유
아래 두개의 deprecated된 의존성을 업데이트 했습니다.

- rollup-plugin-terser@7.0.2
- rollup-plugin-babel@4.4.0

<img width="896" alt="image" src="https://github.com/80000Coding/80000Coding-Web-Client/assets/57925497/8aeef078-fece-4587-a4fd-1c6bce614de9">

- querystring@0.2.0 은 aws-sdk 패키지에 의존성이 있습니다.
- stable@0.1.8 은 svgo에 의존성이 있습니다.
