### PR TITLE
♻️ npm run dev에 packages build 의존성을 추가

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "build": "turbo run build",
     "clean": "turbo run clean && rm -rf node_modules .turbo",
-    "dev": "turbo run dev",
+    "dev": "turbo run dev --filter @80000coding/web",
     "lint": "turbo run lint",
     "start": "npm run start -w @80000coding/web",
     "storybook": "turbo run storybook"

--- a/turbo.json
+++ b/turbo.json
@@ -18,7 +18,8 @@
     },
     "dev": {
       "cache": false,
-      "persistent": true
+      "persistent": true,
+      "dependsOn": ["^build"]
     },
     "clean": {
       "cache": false


### PR DESCRIPTION
## 작업 이유
`npm run dev`시 **web-icons, ui** 패키지 빌드가 우선적으로 이루어지지 않아서 참조 오류가 발생하는 경우를 방지하기위해 build 의존성을 추가합니다.

`npm run dev` script는 `@80000coding/web` 패키지만 실행하도록 수정합니다.

<img width="888" alt="image" src="https://github.com/80000Coding/80000Coding-Web-Client/assets/57925497/3f0b165b-b8eb-4c40-bbb4-679592244d03">
