### PR TITLE
🐛 discord notification scope 변경 - in dev, main

### DIFF
--- a/.github/workflows/chromatic-report.yml
+++ b/.github/workflows/chromatic-report.yml
@@ -96,6 +96,7 @@ jobs:
           edit-mode: replace
 
       - name: Discord notification
+        if: github.ref == 'refs/heads/main' || github.ref == 'refs/heads/dev'
         env:
           DISCORD_WEBHOOK: ${{ secrets.DISCORD_WEBHOOK }}
         uses: Ilshidur/action-discord@master


### PR DESCRIPTION
## 작업 이유
무분별한 알림을 줄이기 위해 dev브랜치, main 브랜치에서의 작업만 알림을 보냅니다