### PR TITLE
🚧 tailwind 기본 단위를 px로 변경

### DIFF
--- a/apps/web/tailwind.config.js
+++ b/apps/web/tailwind.config.js
@@ -1,6 +1,10 @@
 /** @type {import('tailwindcss').Config} */
 const { nextui } = require('@nextui-org/react')
 
+const px0_10 = { ...Array.from(Array(11)).map((_, i) => `${i}px`) }
+const px0_100 = { ...Array.from(Array(101)).map((_, i) => `${i}px`) }
+const px0_200 = { ...Array.from(Array(201)).map((_, i) => `${i}px`) }
+
 module.exports = {
   content: [
     './src/pages/**/*.{js,ts,jsx,tsx,mdx}',
@@ -54,10 +58,19 @@ module.exports = {
     },
     lineHeight: {
       DEFAULT: 1,
-      'A': 1.55,
-      'B': 1.7
+      A: 1.55,
+      B: 1.7,
     },
     extend: {
+      borderWidth: px0_10,
+      fontSize: px0_100,
+      lineHeight: px0_100,
+      minWidth: px0_200,
+      minHeight: px0_200,
+      spacing: px0_200,
+      margin: px0_100,
+      padding: px0_100,
+      gap: px0_10,
       backgroundImage: {
         'gradient-radial': 'radial-gradient(var(--tw-gradient-stops))',
         'gradient-conic': 'conic-gradient(from 180deg at 50% 50%, var(--tw-gradient-stops))',


### PR DESCRIPTION
## 작업 이유
프로젝트 디자인 시스템에서 사용하는 기본 단위가 `px`이기 때문에 tailwind에서 사용할 기본단위도 `px`로 변경합니다.
```jsx
변경 전
<div className='m-[10px] h-[10px]'/>
변경 후
<div className='m-10 h-10'/>
```

## 작업 사항
<img width="466" alt="스크린샷 2023-08-25 오후 9 34 57" src="https://github.com/80000Coding/80000Coding-Web-Client/assets/57925497/9cda187a-78ff-4572-b0fa-be618e78f3a6">

## 이슈 연결
close #108
