### PR TITLE
♻️ LoadingPageIcon svg 교체

### DIFF
--- a/packages/ui/src/animated/LoadingPageIcon.tsx
+++ b/packages/ui/src/animated/LoadingPageIcon.tsx
@@ -1,12 +1,11 @@
-// TODO: StaticAllResultIcon -> LoadingPageIcon 으로 바꿔야함
-import { StaticAllResultIcon } from '@80000coding/web-icons'
+import { StaticLoadingPageIcon } from '@80000coding/web-icons'
 import cn from 'classnames'
 import React from 'react'
 
-type Props = React.ComponentProps<typeof StaticAllResultIcon>
+type Props = React.ComponentProps<typeof StaticLoadingPageIcon>
 
 const LoadingPageIcon = ({ className, ...props }: Props) => {
-  return <StaticAllResultIcon className={cn('animate-spin-with-delay', className)} {...props} />
+  return <StaticLoadingPageIcon className={cn('animate-spin-with-delay', className)} {...props} />
 }
 
 export default LoadingPageIcon


### PR DESCRIPTION
## 작업 이유
LoadingPageIcon이 `StaticAllResultIcon`으로 되어있어서 Figma에 기준에 맞게 `StaticLoadingPageIcon`으로 변경

## 작업 사항
| StaticAllResultIcon | StaticLoadingPageIcon |
|---|---|
|<img width="74" alt="image" src="https://github.com/80000Coding/80000Coding-Web-Client/assets/57925497/9449f5d6-069d-44f4-baa5-5d883813a98b">|<img width="65" alt="image" src="https://github.com/80000Coding/80000Coding-Web-Client/assets/57925497/a462a4fa-95e8-431c-85dd-a601ba29ac26">|


## 이슈 연결
close #123 
