### PR TITLE
fix(web): 파일명 변경 후 import시 에러 수정

### DIFF
--- a/apps/web/tsconfig.json
+++ b/apps/web/tsconfig.json
@@ -3,7 +3,8 @@
   "compilerOptions": {
     "paths": {
       "@/*": ["./src/*"]
-    }
+    },
+    "forceConsistentCasingInFileNames": false
   },
   "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", ".next/types/**/*.ts"],
   "exclude": ["node_modules"]


### PR DESCRIPTION
## 작업 이유
- 파일명을 변경하고 해당 파일이 import 되어있던 곳의 파일명을 바뀐거로 적용하면 요런 에러가 vscode 상에서만 뜹니다.
<img width="477" alt="image" src="https://github.com/80000Coding/80000Coding-Web-Client/assets/76505351/03a9ed9c-021b-4eb4-a2d7-103a7a5e2142">

## 작업 사항
는 해결 https://merrily-code.tistory.com/156
## 이슈 연결

