### PR TITLE
✨ storybook stories sotring, light dark mode addon 추가

### DIFF
--- a/apps/web/.storybook/main.ts
+++ b/apps/web/.storybook/main.ts
@@ -1,6 +1,6 @@
 const path = require('path')
 
-/** @type { import('@storybook/react-vite').StorybookConfig } */
+/** @type { import('@storybook/nextjs').StorybookConfig } */
 const config = {
   stories: ['../**/*.mdx', '../**/*.stories.@(js|jsx|mjs|ts|tsx)'],
   addons: [
@@ -22,6 +22,9 @@ const config = {
   framework: {
     name: '@storybook/nextjs',
     options: {},
+  },
+  options: {
+    storySort: (a, b) => (a.id === b.id ? 0 : a.id.localeCompare(b.id, undefined, { numeric: true })),
   },
 }
 export default config

--- a/apps/web/.storybook/main.ts
+++ b/apps/web/.storybook/main.ts
@@ -8,6 +8,7 @@ const config = {
     '@storybook/addon-essentials',
     '@storybook/addon-onboarding',
     '@storybook/addon-interactions',
+    'storybook-dark-mode',
     {
       name: '@storybook/addon-styling',
       options: {

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -54,6 +54,7 @@
     "chromatic": "^6.22.0",
     "eslint-config-custom": "*",
     "storybook": "^7.1.0",
+    "storybook-dark-mode": "^3.0.1",
     "tailwindcss": "3.3.2",
     "tsconfig": "*"
   }

--- a/package-lock.json
+++ b/package-lock.json
@@ -94,6 +94,7 @@
         "chromatic": "^6.22.0",
         "eslint-config-custom": "*",
         "storybook": "^7.1.0",
+        "storybook-dark-mode": "^3.0.1",
         "tailwindcss": "3.3.2",
         "tsconfig": "*"
       }
@@ -29240,6 +29241,34 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/storybook"
+      }
+    },
+    "node_modules/storybook-dark-mode": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/storybook-dark-mode/-/storybook-dark-mode-3.0.1.tgz",
+      "integrity": "sha512-3V6XBhkUq63BF6KzyDBbfV5/8sYtF4UtVccH1tK+Lrd4p0tF8k7yHOvVDhFL9hexnKXcLEnbC+42YDTPvjpK+A==",
+      "dev": true,
+      "dependencies": {
+        "@storybook/addons": "^7.0.0",
+        "@storybook/api": "^7.0.0",
+        "@storybook/components": "^7.0.0",
+        "@storybook/core-events": "^7.0.0",
+        "@storybook/global": "^5.0.0",
+        "@storybook/theming": "^7.0.0",
+        "fast-deep-equal": "^3.1.3",
+        "memoizerific": "^1.11.3"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0",
+        "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0"
+      },
+      "peerDependenciesMeta": {
+        "react": {
+          "optional": true
+        },
+        "react-dom": {
+          "optional": true
+        }
       }
     },
     "node_modules/stream-browserify": {


### PR DESCRIPTION
## 작업 이유
storybook 파일들이 정렬이 안되어있어서 보기 불편했던 부분을 개선하고 light/dark mode addon을 추가했습니다.

## 작업 사항
- storybook 파일 정렬 
<img width="336" alt="image" src="https://github.com/80000Coding/80000Coding-Web-Client/assets/57925497/70c9a922-bafa-4c4b-a644-de6819af473e">

- storybook light/dark mode addon
<img width="158" alt="스크린샷 2023-08-30 오후 6 52 38" src="https://github.com/80000Coding/80000Coding-Web-Client/assets/57925497/11e7c861-e2ad-401a-ae13-1b5e0668c11a">


## 이슈 연결
close #120 
