### PR TITLE
♻️ refactor clean script 세분화 (build, deps clean)

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -11,8 +11,8 @@
     "storybook": "storybook dev -p 6006",
     "build-storybook": "storybook build",
     "clean": "run-s 'clean:*'",
-    "clean:build": "rm -rf dist",
-    "clean:cache": "rm -rf node_modules .turbo .eslintcache",
+    "clean:build": "rm -rf dist .turbo .eslintcache",
+    "clean:deps": "rm -rf node_modules",
     "chromatic": "npx chromatic --project-token=chpt_e6e5c08f47b0947"
   },
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -6,7 +6,9 @@
   "scripts": {
     "build": "turbo run build",
     "build:packages": "turbo run build --filter='./packages/*'",
-    "clean": "turbo run clean && rm -rf node_modules .turbo",
+    "clean": "turbo run clean",
+    "clean:build": "turbo run clean:build",
+    "clean:cache": "turbo run clean:cache",
     "dev": "turbo run dev",
     "lint": "turbo run lint",
     "storybook": "turbo run storybook",

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "build:packages": "turbo run build --filter='./packages/*'",
     "clean": "turbo run clean",
     "clean:build": "turbo run clean:build",
-    "clean:cache": "turbo run clean:cache",
+    "clean:deps": "turbo run clean:deps",
     "dev": "turbo run dev",
     "lint": "turbo run lint",
     "storybook": "turbo run storybook",

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -16,8 +16,8 @@
     "lint": "run-s lint:*",
     "lint:eslint": "eslint .",
     "clean": "run-s clean:*",
-    "clean:build": "rm -rf dist",
-    "clean:cache": "rm -rf .turbo && rm -rf node_modules"
+    "clean:build": "rm -rf dist .turbo",
+    "clean:deps": "rm -rf"
   },
   "devDependencies": {
     "@rollup/plugin-babel": "^6.0.3",

--- a/packages/web-icons/package.json
+++ b/packages/web-icons/package.json
@@ -18,8 +18,8 @@
     "dev": "rollup -c -w",
     "build": "rollup -c",
     "clean": "run-s 'clean:*'",
-    "clean:build": "rm -rf dist",
-    "clean:cache": "rm -rf node_modules .turbo .eslintcache stats.html"
+    "clean:build": "rm -rf dist .turbo stats.html",
+    "clean:deps": "rm -rf node_modules"
   },
   "files": [
     "dist"

--- a/turbo.json
+++ b/turbo.json
@@ -29,7 +29,7 @@
     "clean:build": {
       "cache": false
     },
-    "clean:cache": {
+    "clean:deps": {
       "cache": false
     }
   }

--- a/turbo.json
+++ b/turbo.json
@@ -25,6 +25,12 @@
     },
     "clean": {
       "cache": false
+    },
+    "clean:build": {
+      "cache": false
+    },
+    "clean:cache": {
+      "cache": false
     }
   }
 }


### PR DESCRIPTION
## 작업 이유
clean 스크립트 사용시 node_modules 등 의존성 파일까지 모두 지워버려서 clean 후 다시 빌드하기까지 오랜 시간이 걸렸습니다. build, cache, dependancies를 위한 clean을 세부적으로 분리해서 필요한 스크립트를 사용할 수 있도록 변경했습니다.

## 작업 사항
```shell
# all
npm run clean

# build (dist or .turbo)
npm run clean:build

# deps
npm run clean:deps
```

