### PR TITLE
✨ next build시 app/test 하위 페이지들은 제외

### DIFF
--- a/apps/web/next.config.js
+++ b/apps/web/next.config.js
@@ -1,5 +1,21 @@
 /** @type {import('next').NextConfig} */
 const nextConfig = {
+  /**
+   *
+   * @param {import('webpack').Configuration} config
+   * @param {import('next/dist/server/config-shared').WebpackConfigContext} context
+   * @returns {import('webpack').Configuration}
+   */
+  webpack: (config) => {
+    if (process.env.NEXT_OUTPUT_MODE !== 'export' || !config.module) {
+      return config
+    }
+    config.module.rules?.push({
+      test: /src\/app\/test/,
+      loader: 'ignore-loader',
+    })
+    return config
+  },
   experimental: {
     externalDir: true,
   },

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -52,6 +52,7 @@
     "@types/react-dom": "18.2.6",
     "chromatic": "^6.22.0",
     "eslint-config-custom": "*",
+    "ignore-loader": "^0.1.2",
     "storybook": "^7.1.0",
     "storybook-dark-mode": "^3.0.1",
     "tailwindcss": "3.3.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -92,6 +92,7 @@
         "@types/react-dom": "18.2.6",
         "chromatic": "^6.22.0",
         "eslint-config-custom": "*",
+        "ignore-loader": "^0.1.2",
         "storybook": "^7.1.0",
         "storybook-dark-mode": "^3.0.1",
         "storybook-tailwind-dark-mode": "^1.0.22",
@@ -20103,6 +20104,12 @@
       "engines": {
         "node": ">= 4"
       }
+    },
+    "node_modules/ignore-loader": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/ignore-loader/-/ignore-loader-0.1.2.tgz",
+      "integrity": "sha512-yOJQEKrNwoYqrWLS4DcnzM7SEQhRKis5mB+LdKKh4cPmGYlLPR0ozRzHV5jmEk2IxptqJNQA5Cc0gw8Fj12bXA==",
+      "dev": true
     },
     "node_modules/image-size": {
       "version": "1.0.2",


### PR DESCRIPTION
## 작업 이유
next build시 개발용으로 작성된 app/test 하위의 페이지까지 빌드해 불필요한 오류가 출력되는 경우가 있었습니다. 개발용으로 작성된 페이지를 build 시점에 제외할 수 있도록 기능을 추가하였습니다.

## 작업 사항
현재 `dev` 브랜치에서 build시 test/chip/page.tsx 의 최상단에 `'use client'`가 빠져있어 build가 안되고 있습니다. 
이제 테스트용 page에서는 이러한 불필요한 빌드 오류를 출력하지 않습니다.

## 이슈 연결
