### PR TITLE
🐛 client side component 최상단에 'use client' 추가

### DIFF
--- a/apps/web/src/app/test/chip/page.tsx
+++ b/apps/web/src/app/test/chip/page.tsx
@@ -1,3 +1,4 @@
+'use client'
 import { Chip, IconChip } from '@80000coding/ui'
 
 // import { icons } from '@80000coding/web-icons'


### PR DESCRIPTION
## 작업 사항
현재 dev 브랜치에서 build시 test/chip/page.tsx 의 최상단에 'use client'가 빠져있어 build가 안되고 있습니다.
해당 문제를 수정했습니다.

## 이슈 연결

