### PR TITLE
✨ profile page storybook 추가

### DIFF
--- a/apps/web/.storybook/main.ts
+++ b/apps/web/.storybook/main.ts
@@ -1,4 +1,4 @@
-const path = require('path')
+const TsconfigPathsPlugin = require('tsconfig-paths-webpack-plugin')
 
 /** @type { import('@storybook/nextjs').StorybookConfig } */
 const config = {
@@ -18,6 +18,11 @@ const config = {
       },
     },
   ],
+  staticDirs: ['../public'],
+  webpackFinal: async (config, { configType }) => {
+    config.resolve.plugins = [new TsconfigPathsPlugin()]
+    return config
+  },
   framework: {
     name: '@storybook/nextjs',
     options: {},

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -57,6 +57,7 @@
     "storybook-dark-mode": "^3.0.1",
     "storybook-tailwind-dark-mode": "^1.0.22",
     "tailwindcss": "3.3.2",
-    "tsconfig": "*"
+    "tsconfig": "*",
+    "tsconfig-paths-webpack-plugin": "^4.1.0"
   }
 }

--- a/apps/web/src/stories/pages/Profile.stories.tsx
+++ b/apps/web/src/stories/pages/Profile.stories.tsx
@@ -1,0 +1,20 @@
+import type { Meta, StoryObj } from '@storybook/react'
+
+import { default as Profile$1 } from '../../app/profile/[id]/page'
+
+const meta = {
+  title: 'Pages/Profile',
+  component: Profile$1,
+  parameters: {
+    nextjs: {
+      appDirectory: true,
+    },
+  },
+} satisfies Meta<typeof Profile$1>
+
+export default meta
+type Story = StoryObj<typeof meta>
+
+export const Profile: Story = {
+  args: {},
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -97,7 +97,8 @@
         "storybook-dark-mode": "^3.0.1",
         "storybook-tailwind-dark-mode": "^1.0.22",
         "tailwindcss": "3.3.2",
-        "tsconfig": "*"
+        "tsconfig": "*",
+        "tsconfig-paths-webpack-plugin": "^4.1.0"
       }
     },
     "node_modules/@80000coding/ui": {


### PR DESCRIPTION
## 작업 이유
프로필 페이지를 스토리북에 추가합니다.
<img width="695" alt="image" src="https://github.com/80000Coding/80000Coding-Web-Client/assets/57925497/b9a127e6-ce72-4a14-8697-2286f9282b9c">

## 작업 사항
- import alias 적용을 위해 `tsconfig-paths-webpack-plugin` 설치
- static assets 적용을 위해 storybook config에 staticDir 설정
- 프로필 페이지 storybook 추가

## 이슈 연결

