### PR TITLE
🚧 [헬프미] colorBase.ts 생성, Button 과 Chip에 적용

### DIFF
--- a/apps/web/src/app/test/theme/page.tsx
+++ b/apps/web/src/app/test/theme/page.tsx
@@ -1,15 +1,38 @@
 'use client'
 
-import { Button, ThemeDropdown } from '@80000coding/ui'
-import cn from 'classnames'
+import { Alert, Button, Chip, IconChip, ThemeDropdown } from '@80000coding/ui'
+import { useDisclosure } from '@nextui-org/react'
 
 export default function AlertPage() {
+  const { isOpen, onOpen, onClose } = useDisclosure()
   return (
     <>
-      <div className={cn('bg-red', 'dark:bg-white dark:text-black')}>hello</div>
-      <Button text='GitHub로 계속하귕' className='bg-black dark:bg-white' />
-      <Button text='primary' variant='primary' className='bg-green' />
-      <Button text='outline' variant='outline' className='bg-red' />
+      <Button text='primary' variant='primary' />
+      <Button text='secondary' variant='secondary' />
+      <Button text='warning' variant='warning' />
+      <div className='flex p-[20px]'>
+        <Chip text='chip' />
+        <IconChip size='md' />
+      </div>
+      <Button text='Alert Test' variant='secondary' onClick={onOpen} />
+      <Alert
+        onClose={onClose}
+        isOpen={isOpen}
+        firstButton={{
+          action: () => {
+            onClose()
+          },
+          text: '닫기',
+          variant: 'secondary',
+        }}
+        secondButton={{
+          action: () => {},
+          text: '저장',
+          variant: 'primary',
+        }}
+        header='hello'
+        body='hello'
+      />
       <ThemeDropdown />
     </>
   )

--- a/apps/web/src/app/typo.css
+++ b/apps/web/src/app/typo.css
@@ -34,7 +34,7 @@
 }
 
 .body-1 {
-  @apply leading text-lg font-bold;
+  @apply leading-A2 text-lg font-bold;
 }
 .body-1A {
   @apply leading-A2 text-lg font-bold;

--- a/apps/web/tailwind.config.js
+++ b/apps/web/tailwind.config.js
@@ -1,4 +1,5 @@
 /** @type {import('tailwindcss').Config} */
+const plugin = require('tailwindcss/plugin')
 const { nextui } = require('@nextui-org/react')
 
 module.exports = {
@@ -94,5 +95,12 @@ module.exports = {
       },
     },
   },
-  plugins: [nextui()],
+  plugins: [nextui(),
+  plugin(function ({ addVariant }) {
+    addVariant('base', '&.base')
+    addVariant('primary', '&.primary')
+    addVariant('secondary', '&.secondary')
+    addVariant('warning', '&.warning')
+    addVariant('symbol', '&.symbol')
+  })],
 }

--- a/packages/ui/src/button/Button.tsx
+++ b/packages/ui/src/button/Button.tsx
@@ -1,8 +1,10 @@
 import cn from 'classnames'
 import React from 'react'
 
-type ButtonStyleVariant = 'primary' | 'outline'
-type ButtonSize = 'sm' | 'md' | 'lg'
+import colorBase from '../colorBase'
+
+type ButtonStyleVariant = 'primary' | 'secondary' | 'warning' | 'symbol'
+type ButtonSize = 'full' | 'half' | 'small'
 
 type Props = {
   text?: string
@@ -19,45 +21,23 @@ const Button = ({
   variant = 'primary',
   warning = false,
   loading = false,
-  size = 'md',
+  size = 'full',
   leftIcon,
   rightIcon,
   className,
   children,
   ...rest
 }: Props) => {
-  const sizeToClass = {
-    sm: 'rounded-[16px] h-[32px] note-3',
-    md: 'rounded-[24px] h-[48px] body-1',
-    lg: 'rounded-[26px] h-[52px] title-1',
+  const buttonBase = {
+    'w-full': true,
+    'px-[20px]': true,
+    'py-[14px]': true,
+    'rounded-[16px]': true,
+    'body-1': true,
   }
 
-  const variantToClass = {
-    primary: `text-white`,
-    outline: `border bg-transparent`,
-  }
-
-  const disabledStyleVariantToClass = {
-    primary: `disabled:bg-gray-200`,
-    outline: `disabled:text-gray-200 disabled:border-gray-200`,
-  }
-
-  const warningStyleVariantToClass = {
-    primary: `bg-red-dark`,
-    outline: `border-red-dark text-red-dark`,
-  }
   return (
-    <button
-      className={cn(
-        'w-full px-[24px]',
-        sizeToClass[size],
-        variantToClass[variant],
-        disabledStyleVariantToClass[variant],
-        warning && warningStyleVariantToClass[variant],
-        className,
-      )}
-      {...rest}
-    >
+    <button className={cn(variant, buttonBase, colorBase, className)} {...rest}>
       <div className='align-center flex flex-row items-center justify-center gap-[2px]'>
         {leftIcon}
         <span className='overflow-hidden text-ellipsis whitespace-nowrap'>{text ?? children}</span>

--- a/packages/ui/src/chip/IconChip.tsx
+++ b/packages/ui/src/chip/IconChip.tsx
@@ -1,5 +1,6 @@
 import cn from 'classnames'
 
+import colorBase from '../colorBase'
 import { CategoryIconNames, categoryIcons } from '../icon'
 
 type IconChipProps = {
@@ -9,8 +10,8 @@ type IconChipProps = {
 
 const IconChip = ({ size = 'sm', categoryIconNames = 'AppleDeveloperAcademy', className, ...rest }: IconChipProps) => {
   const chipClassBySize = {
-    sm: 'caption-3 pl-[23px] pr-[10px] py-[5px] bg-white',
-    md: 'caption-1 pl-[34px] pr-[12px] py-[10.5px] bg-gray-100',
+    sm: 'caption-3 pl-[23px] pr-[10px] py-[5px] ',
+    md: 'caption-1 pl-[34px] pr-[12px] py-[10.5px] ',
   }
 
   const iconClassBySize = {
@@ -20,7 +21,7 @@ const IconChip = ({ size = 'sm', categoryIconNames = 'AppleDeveloperAcademy', cl
   const chipStyle = { boxShadow: `inset 0 0 0 1px ${categoryIcons[categoryIconNames].bgColor}` }
 
   return (
-    <span className={cn('relative rounded-full text-gray-700', chipClassBySize[size], className)} style={chipStyle} {...rest}>
+    <span className={cn('relative rounded-full ', chipClassBySize[size], colorBase, className)} style={chipStyle} {...rest}>
       {categoryIcons[categoryIconNames].source({ className: 'absolute ' + iconClassBySize[size] })}
       {categoryIcons[categoryIconNames].displayName}
     </span>

--- a/packages/ui/src/colorBase.ts
+++ b/packages/ui/src/colorBase.ts
@@ -1,0 +1,8 @@
+const colorBase = {
+  'primary:bg-green primary:dark:bg-green-dark': true,
+  'secondary:bg-gray-100 secondary:dark:bg-gray-500': true,
+  'warning:bg-red warning:dark:bg-red-warning': true,
+  'bg-gray-100 text-gray-700 dark:bg-gray-900 dark:text-gray-200': true,
+}
+
+export default colorBase


### PR DESCRIPTION
## 작업 사항

- 색상이 바뀔 때 한번에 바뀌도록 colorBase.ts 를 따로 작성하여 해당 파일에서 바뀌도록 설정
- 테마가 dark-light 바뀔 때 다른 설정 없이 colorBase 적용하면 바로 바뀌도록 설정
- 작업하면서 컴포넌트가 피그마와 달라진 부분들을 조금씩 수정한 부분도 있음.
- 작업 사항은 /test/theme 페이지에서 다크/라이트 모드 변경해보면 확인 가능..!

## 고민

- 해당 파일은 버튼과 chip에서만 적용 가능
- 결국 'primary', 'secondary', 'base' 등 모든 타입의 text color, background가 모두 다르기 때문에 colorBase에 각각 따로 적용을 시켜줘야 함
- 'primary', 'secondary' 등의 속성은 Button 에서만 쓰이는 variant인데, 이걸 tailwind의 플러그인으로 두는 게 괜찮을지 모르겠음.

- 결국 컴포넌트별로 colorBase를 따로 따로 두는 게 맞을 지
- 그렇다면 굳이 또 base를 만들어야 할지...?!


문제점이 뭐였는지조차 헷갈리는 지경이 와버려서 일단 냅다 올려두고 리뷰를 받아볼까 합니다... 이상한 부분 마구 지적 부탁드립니다


## 이슈 연결
#172 

